### PR TITLE
Add /stream/ API endpoint with unit tests

### DIFF
--- a/.travis-docker-compose.yml
+++ b/.travis-docker-compose.yml
@@ -1,4 +1,5 @@
 # Travis specific docker-compose to handle database and server dependencies
+# Mount the README.md as the test file to serve over /stream/
 omp-express-mongo-api:
     build: .
     working_dir: /omp
@@ -7,9 +8,10 @@ omp-express-mongo-api:
         - ./server.js:/omp/server.js:rw
         - ./routes/:/omp/routes/:rw
         - ./dao/:/omp/dao/:rw
+        - ./README.md:/omp/README.md:rw
     environment:
+        LIBRARY_ROOT: /omp/
         NODE_ENV: development
-        NODE_PATH: /usr/local/lib/node_modules/omp-express-mongo-api/node_modules/
     ports:
         - "8001:8001"
     links:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /omp
 
 # Install app dependencies
 COPY ./package.json ./package.json
-RUN npm install --global --production
+RUN npm install --production
 RUN rm ./package.json
 
 # The rest of the code will be mounted as a volume

--- a/dao/file.js
+++ b/dao/file.js
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Generic file schema
+ *
+ * @author ojourmel
+ */
+
+var mongoose = require('mongoose'),
+    Schema = mongoose.Schema;
+
+var fileSchema = new Schema({
+    name: {type: String },
+    format: {type: String },
+    path: {type: String }
+}, { collection : 'files', discriminatorKey : '_type' });
+
+module.exports = mongoose.model('file',fileSchema);

--- a/dao/music.js
+++ b/dao/music.js
@@ -5,16 +5,16 @@
  */
 
 var mongoose = require('mongoose'),
+    extend = require('mongoose-schema-extend'),
+    fileSchema = require('./file').schema,
     Schema = mongoose.Schema,
     ObjectId = Schema.ObjectId;
 
-var musicSchema = new Schema({
-    name: {type: String },
+var musicSchema = fileSchema.extend({
     year: {type: String },
     artist: {type: String },
     album: {type: String },
-    label: {type: String },
-    path: {type: String }
+    label: {type: String }
 });
 
 module.exports = mongoose.model('music', musicSchema);

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
         "multer": "1.x",
         "bson": "0.x",
         "mongodb": "2.x",
-        "mongoose": "4.x"
+        "mongoose": "4.x",
+        "mongoose-schema-extend": "0.x",
+        "path": "0.x"
     },
     "devDependencies":{
         "mocha": "2.x",
         "supertest": "1.x"
     },
     "scripts": {
-        "start": "node server.js",
+        "start": "node --harmony_proxies server.js",
         "test": "./node_modules/mocha/bin/mocha"
     }
 }

--- a/routes/music.js
+++ b/routes/music.js
@@ -31,7 +31,7 @@ exports.findById = function(req, res) {
         } else {
             res.send(m);
         }
-    })
+    });
 };
 
 /**
@@ -45,9 +45,10 @@ exports.addMusic = function(req, res) {
                         artist: req.body.artist,
                         album: req.body.album,
                         label: req.body.label,
+                        format: req.body.format,
                         path: req.body.path});
 
-    if (m.name && m.path) {
+    if (m.name && m.path && m.format) {
         m.save(function(err){
             if (err) {
                 res.status(500).send({'error':'Internal Server Error'},
@@ -74,9 +75,10 @@ exports.updateMusic = function(req, res) {
             m.artist = req.body.artist;
             m.album = req.body.album;
             m.label = req.body.label;
+            m.format = req.body.format;
             m.path = req.body.path;
 
-            if (m.name && m.path) {
+            if (m.name && m.path && m.format) {
                 m.save(function(err){
                     if (err) {
                         res.status(500).send({'error':'Internal Server Error'},

--- a/routes/stream.js
+++ b/routes/stream.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Generic file serving endpoint
+ *
+ * @author ojourmel
+ */
+
+var LIBRARYROOT = process.env.LIBRARY_ROOT;
+var file = require('../dao/file'),
+    fs = require('fs'),
+    path = require('path');
+
+
+/**
+ * get /serve/:id
+ *
+ */
+exports.serve = function(req, res) {
+    file.findOne({_id: req.params.id}).lean().exec(function(err, f) {
+        if (err || !f) {
+            res.status(404).send({'error':'Not Found'});
+        } else {
+            var filepath = path.join(LIBRARYROOT, f.path);
+            var readStream = fs.createReadStream(filepath);
+
+            readStream.on('open', function () {
+                res.set({'Content-Type': f.format});
+                readStream.pipe(res);
+            });
+
+            readStream.on('error', function(err) {
+                console.log(err);
+                res.status(404).send({'error':'Not Found'});
+            });
+        }
+    });
+}

--- a/server.js
+++ b/server.js
@@ -7,14 +7,13 @@
  * @author ojourmel
  */
 
-// Load global node packages
-var NODE_PATH = process.env.NODE_PATH
-var express = require(NODE_PATH + 'express'),
-    logger = require(NODE_PATH + 'morgan'),
-    bodyParser = require(NODE_PATH + 'body-parser'),
-    multer = require(NODE_PATH + 'multer'),
-    mongoose = require(NODE_PATH + 'mongoose'),
-    music = require('./routes/music');
+var express = require('express'),
+    logger = require('morgan'),
+    bodyParser = require('body-parser'),
+    multer = require('multer'),
+    mongoose = require('mongoose'),
+    music = require('./routes/music'),
+    stream = require('./routes/stream');
 
 var app = express();
 
@@ -38,6 +37,8 @@ app.get('/music/:id', music.findById);
 app.post('/music', music.addMusic);
 app.put('/music/:id', music.updateMusic);
 app.delete('/music/:id', music.deleteMusic);
+
+app.get('/stream/:id', stream.serve);
 
 app.listen(8001);
 console.log('Listening on port 8001...');

--- a/test/jsonProperty.js
+++ b/test/jsonProperty.js
@@ -1,0 +1,27 @@
+/**
+*
+* jsonProperty.equal is used to avoid bad mocha checks of returning JSON
+*
+* Use the following code structure:
+*
+*    .expect(function(res) {
+*         var r = jsonProperty.equal(res.body.p1 , object.p1) ||
+*                 jsonProperty.equal(res.body.p2 , object.p2) ||
+*                 jsonProperty.equal(res.body.p3 , object.p3);
+*
+*         if (r) {
+*             throw new Error(r);
+*         }
+*    })
+*
+* @author ojourmel
+*/
+
+exports.equal = function (j1, j2)
+{
+    if (j1 != j2) {
+        return "Error: " + j1 + " != " + j2;
+    } else {
+        return null;
+    }
+}

--- a/test/music.js
+++ b/test/music.js
@@ -1,11 +1,12 @@
 /**
 * Testing for music api
 *
-* @see jsonEqual to avoid bad mocha checks of returning JSON
+* @see jsonProperty to avoid bad mocha checks of returning JSON
 *
 * @author ojourmel
 */
-var request = require('supertest');
+var request = require('supertest'),
+    jsonProperty = require('./jsonProperty');
 
 // Connect to an alread running instance of the app
 // This includes are running docker-compose instance
@@ -18,17 +19,19 @@ var music = {
     artist: "TestArtist",
     album: "TestAlbum",
     label: "TestLabel",
+    format: "TestFormat",
     path: "TestPath"
 };
 
 var extra = {
-    name: "ExtraNaem",
+    name: "ExtraName",
     year: "9999",
-    artist: "TestArtist",
-    album: "TestAlbum",
-    label: "TestLabel",
-    path: "TestPath",
-    extra: "EXTRA"
+    artist: "ExtraArtist",
+    album: "ExtraAlbum",
+    label: "ExtraLabel",
+    format: "ExtraFormat",
+    path: "ExtraPath",
+    extra: "Extra"
 
 };
 
@@ -48,14 +51,15 @@ describe('music api', function () {
             .send(music)
             .expect('Content-Type', /json/)
             .expect(function(res) {
-                var r = jsonEqual(res.body.name , music.name) ||
-                       jsonEqual(res.body.year , music.year) ||
-                       jsonEqual(res.body.artist , music.artist) ||
-                       jsonEqual(res.body.album , music.album) ||
-                       jsonEqual(res.body.label , music.label) ||
-                       jsonEqual(res.body.path , music.path)
+                var r = jsonProperty.equal(res.body.name , music.name) ||
+                       jsonProperty.equal(res.body.year , music.year) ||
+                       jsonProperty.equal(res.body.artist , music.artist) ||
+                       jsonProperty.equal(res.body.album , music.album) ||
+                       jsonProperty.equal(res.body.label , music.label) ||
+                       jsonProperty.equal(res.body.format , music.format) ||
+                       jsonProperty.equal(res.body.path , music.path);
 
-                if (r){
+                if (r) {
                     throw new Error(r);
                 }
             })
@@ -78,15 +82,16 @@ describe('music api', function () {
             .expect('Content-Type', /json/)
             .expect(function(res) {
 
-                var r = jsonEqual(res.body.name , extra.name) ||
-                       jsonEqual(res.body.year , extra.year) ||
-                       jsonEqual(res.body.artist , extra.artist) ||
-                       jsonEqual(res.body.album , extra.album) ||
-                       jsonEqual(res.body.label , extra.label) ||
-                       jsonEqual(res.body.path , extra.path) ||
-                       jsonEqual(res.body.extra , null);
+                var r = jsonProperty.equal(res.body.name , extra.name) ||
+                       jsonProperty.equal(res.body.year , extra.year) ||
+                       jsonProperty.equal(res.body.artist , extra.artist) ||
+                       jsonProperty.equal(res.body.album , extra.album) ||
+                       jsonProperty.equal(res.body.label , extra.label) ||
+                       jsonProperty.equal(res.body.format , extra.format) ||
+                       jsonProperty.equal(res.body.path , extra.path) ||
+                       jsonProperty.equal(res.body.extra , null);
 
-                if (r){
+                if (r) {
                     throw new Error(r);
                 }
 
@@ -105,6 +110,7 @@ describe('music api', function () {
     it('should 400 empty path /music post', function (done) {
         var tmp = {
             name: 'empty',
+            format: 'exe',
             year: 'thing'
         }
 
@@ -117,6 +123,20 @@ describe('music api', function () {
 
     it('should 400 empty name /music post', function (done) {
         var tmp = {
+            year: 'thing',
+            format: 'exe',
+            path: '/path/'
+        }
+        request
+            .post('/music')
+            .set('Content-Type', 'application/json')
+            .send(tmp)
+            .expect(400, done);
+    });
+
+    it('should 400 empty format /music post', function (done) {
+        var tmp = {
+            name: 'name',
             year: 'thing',
             path: '/path/'
         }
@@ -147,14 +167,15 @@ describe('music api', function () {
             .expect('Content-Type', /json/)
             .expect(function(res) {
 
-                var r = jsonEqual(res.body.name , music.name) ||
-                       jsonEqual(res.body.year , music.year) ||
-                       jsonEqual(res.body.artist , music.artist) ||
-                       jsonEqual(res.body.album , music.album) ||
-                       jsonEqual(res.body.label , music.label) ||
-                       jsonEqual(res.body.path , music.path)
+                var r = jsonProperty.equal(res.body.name , music.name) ||
+                       jsonProperty.equal(res.body.year , music.year) ||
+                       jsonProperty.equal(res.body.artist , music.artist) ||
+                       jsonProperty.equal(res.body.album , music.album) ||
+                       jsonProperty.equal(res.body.label , music.label) ||
+                       jsonProperty.equal(res.body.format , music.format) ||
+                       jsonProperty.equal(res.body.path , music.path);
 
-                if (r){
+                if (r) {
                     throw new Error(r);
                 }
 
@@ -179,14 +200,15 @@ describe('music api', function () {
             .send(music)
             .expect('Content-Type', /json/)
             .expect(function(res) {
-                var r = jsonEqual(res.body.name , music.name) ||
-                       jsonEqual(res.body.year , music.year) ||
-                       jsonEqual(res.body.artist , music.artist) ||
-                       jsonEqual(res.body.album , music.album) ||
-                       jsonEqual(res.body.label , music.label) ||
-                       jsonEqual(res.body.path , music.path)
+                var r = jsonProperty.equal(res.body.name , music.name) ||
+                       jsonProperty.equal(res.body.year , music.year) ||
+                       jsonProperty.equal(res.body.artist , music.artist) ||
+                       jsonProperty.equal(res.body.album , music.album) ||
+                       jsonProperty.equal(res.body.label , music.label) ||
+                       jsonProperty.equal(res.body.format , music.format) ||
+                       jsonProperty.equal(res.body.path , music.path);
 
-                if (r){
+                if (r) {
                     throw new Error(r);
                 }
             })
@@ -212,14 +234,15 @@ describe('music api', function () {
             .get('/music/' + music._id)
             .expect('Content-Type', /json/)
             .expect(function(res) {
-                var r = jsonEqual(res.body.name , music.name) ||
-                       jsonEqual(res.body.year , music.year) ||
-                       jsonEqual(res.body.artist , music.artist) ||
-                       jsonEqual(res.body.album , music.album) ||
-                       jsonEqual(res.body.label , music.label) ||
-                       jsonEqual(res.body.path , music.path)
+                var r = jsonProperty.equal(res.body.name , music.name) ||
+                       jsonProperty.equal(res.body.year , music.year) ||
+                       jsonProperty.equal(res.body.artist , music.artist) ||
+                       jsonProperty.equal(res.body.album , music.album) ||
+                       jsonProperty.equal(res.body.label , music.label) ||
+                       jsonProperty.equal(res.body.format , music.format) ||
+                       jsonProperty.equal(res.body.path , music.path);
 
-                if (r){
+                if (r) {
                     throw new Error(r);
                 }
             })
@@ -259,16 +282,3 @@ describe('music api', function () {
     });
 
 });
-
-/**
- * @TODO Make this function global to all testing scripts
- *
- */
-function jsonEqual(j1, j2)
-{
-    if (j1 != j2) {
-        return "Error: " + j1 + " != " + j2;
-    } else {
-        return null;
-    }
-}

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,0 +1,64 @@
+/**
+* Testing for stream api
+*
+* @see jsonProperty to avoid bad mocha checks of returning JSON
+* @see test/music to verify that the /music code is working
+* @author ojourmel
+*/
+var request = require('supertest'),
+    jsonProperty = require('./jsonProperty');
+
+// Connect to an alread running instance of the app
+// This includes are running docker-compose instance
+request = request("http://localhost:8001");
+
+// Use the README.md file for testing purposes
+// This file is mounted in .travis-docker-compose.yml
+var file = {
+    name: "readme",
+    format: "text/plain",
+    path: "README.md"
+};
+
+describe('stream api', function () {
+
+    it('should 404 a bad id /stream/:id get', function (done) {
+        request
+            .get('/stream/' + 'badid')
+            .expect(404, done);
+    });
+
+
+    // chain requests as they are done asynchronously
+    it('should respond to /stream/:id get', function (done) {
+
+        // Ugly dependency on /music/ to populate test data
+        request
+            .post('/music/')
+            .set('Content-Type', 'application/json')
+            .send(file)
+            .end(function (perr, res) {
+                file._id = res.body._id;
+
+                // here is the actual test
+                request
+                    .get('/stream/' + file._id)
+                    .expect('Content-Type', new RegExp('^' + file.format + '.*'))
+                    .expect(200)
+                    .end(function (err, res) {
+
+                        // Clean up test data, again, dependent on /music/
+                        request
+                            .delete('/music/' + file._id)
+                            .end(function (derr, res){
+
+                                if (err) {
+                                    done(err);
+                                } else {
+                                    done();
+                                }
+                            });
+                    });
+            });
+    });
+});


### PR DESCRIPTION
- Improve mongoose models to use a template `file`.
  This allows easy searching in `/stream/`.
- Improve testing infrastructure by exporting `jsonProperty.equal()`.
- Remove `NODE_PATH` as docker no longer masks `/omp/` folder with
  a volume. Rather, individual folders and files are mounted.
  This fixes lots of issues with the node `fs` package.
- Mount `README.md` as part of `.travis-docker-compose.yml` to
  test `/stream/`'s ability to serve a static file. This does
  does nothing to test other filetypes, but there is no
  difference in the way that those files are served.
- The `file` mongoose model uses the `format` key to record
  the `MIME-Type` of the file.
