### PR TITLE
Add /library/ endpoint and configuration modules

### DIFF
--- a/.travis-docker-compose.yml
+++ b/.travis-docker-compose.yml
@@ -6,11 +6,13 @@ omp-express-mongo-api:
     volumes:
         - ./package.json:/omp/package.json:rw
         - ./server.js:/omp/server.js:rw
+        - ./config.js:/omp/config.js:rw
         - ./routes/:/omp/routes/:rw
         - ./dao/:/omp/dao/:rw
+        - ./.travis-omp-config.yml:/omp/omp-config.yml:rw
         - ./README.md:/omp/README.md:rw
     environment:
-        LIBRARY_ROOT: /omp/
+        OMP_LIBRARY_ROOT: /omp/
         NODE_ENV: development
     ports:
         - "8001:8001"

--- a/.travis-omp-config.yml
+++ b/.travis-omp-config.yml
@@ -1,0 +1,7 @@
+LIBRARY:
+    MUSIC: []
+    PHOTOS: []
+    TV: []
+    MOVIES: []
+    OTHER: []
+API_PORT: 8001

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Use [OpenMediaPortal](https://github.com/OpenMediaPortal/OpenMediaPortal) to get
 
    * [Commit Message Format](http://chris.beams.io/posts/git-commit/)
 
+   * [API Best Practices](http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#requirements)
+
 ## Testing
 
 [![Build Status](https://travis-ci.org/OpenMediaPortal/omp-express-mongo-api.svg?branch=master)](https://travis-ci.org/OpenMediaPortal/omp-express-mongo-api)

--- a/config.js
+++ b/config.js
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Config and constants for OMP
+ *
+ * Uses yml parser to interact with omp-config.yml
+ *
+ * @author ojourmel
+ */
+
+var fs = require('fs'),
+    yaml = require('js-yaml');
+
+var config = {};
+
+// A few constants can be set by the environment
+config.CONFIG_PATH = process.env.OMP_CONFIG_PATH || './omp-config.yml';
+config.NODE_ENV = process.env.NODE_ENV || 'development';
+config.MONGO_HOST = process.env.OMP_MONGO_HOST || 'omp-mongo';
+config.LIBRARY_ROOT = process.env.OMP_LIBRARY_ROOT || '/srv/data/';
+
+
+// initalize all possible options so that we can freeze config
+config.raw = {};
+config.API_PORT = 8001;
+config.LIBRARY = {};
+config.LIBRARY.MUSIC = [];
+config.LIBRARY.PHOTOS = [];
+config.LIBRARY.TV = [];
+config.LIBRARY.MOVIES = [];
+config.LIBRARY.OTHER = [];
+
+// Throw an exception on bad config path
+config.load = function() {
+    this.raw = yaml.safeLoad(fs.readFileSync(this.CONFIG_PATH));
+    this.LIBRARY = this.raw.LIBRARY;
+    this.API_PORT = this.raw.API_PORT;
+}
+
+config.save = function() {
+    this.raw.LIBRARY = this.LIBRARY;
+    this.raw.API_PORT = this.API_PORT;
+    fs.writeFileSync(this.CONFIG_PATH, yaml.safeDump(this.raw, {indent: 4}));
+}
+
+/*
+ * Set constants.
+ * The values set in CONFIG_PATH however, are not frozen
+ * and can be freely modified.
+ *
+ */
+Object.freeze(config.CONFIG_PATH);
+Object.freeze(config.NODE_ENV);
+Object.freeze(config.MONGO_HOST);
+Object.freeze(config.LIBRARY_ROOT);
+
+/*
+ * Overwrite module export object to be config
+ * @see http://www.hacksparrow.com/node-js-exports-vs-module-exports.html
+ *
+ */
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "mongodb": "2.x",
         "mongoose": "4.x",
         "mongoose-schema-extend": "0.x",
-        "path": "0.x"
+        "path": "0.x",
+        "js-yaml": "3.x"
     },
     "devDependencies":{
         "mocha": "2.x",

--- a/routes/library.js
+++ b/routes/library.js
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview Library endpoint
+ *
+ * This end point will be used to sync the library paths with the database
+ * and will interact with omp-config.yml file
+ *
+ * @author ojourmel
+ */
+
+var file = require('../dao/file'),
+    config = require('../config');
+
+
+var typeJson = new RegExp('^application/json');
+
+/**
+ * get /library
+ *
+ */
+exports.index = function(req, res) {
+    config.load();
+    res.send(config.LIBRARY);
+}
+
+/**
+ * get /library/:key
+ *
+ * @example /library/music
+ */
+exports.show = function(req, res) {
+    var key = req.params.key.toUpperCase();
+    if (config.LIBRARY[key]) {
+        res.send(config.LIBRARY[key]);
+    } else {
+        res.status(404).send({'error':'Not Found'});
+    }
+}
+
+/**
+ * post /library
+ *
+ * Replace the entire library path
+ */
+exports.create = function(req, res) {
+
+    if (! typeJson.test(req.get('Content-Type'))) {
+        return res.status(415).send({'error':'Unsupported Media Type'});
+    }
+
+    var lib = req.body;
+    // Disallow library types that are not build in to config
+    // and add back the types missing in the res
+    for (var prop in lib) {
+
+        if (! config.LIBRARY.hasOwnProperty(prop)) {
+            return res.status(400).send({'error':'Bad Format', 'message':'Invalid Property', 'property':prop});
+        }
+
+        if (! (lib[prop] instanceof Array)) {
+            return res.status(400).send({'error':'Bad Format', 'message':'Invalid Type', 'property':prop});
+        }
+    }
+
+    for (var prop in config.LIBRARY) {
+        if (! lib.hasOwnProperty(prop)) {
+            lib[prop] = [];
+        }
+    }
+
+    config.LIBRARY = lib;
+    config.save();
+    res.send(config.LIBRARY);
+}
+
+/**
+ * put /library/:key
+ *
+ * Replace the key
+ */
+exports.update = function(req, res) {
+
+    if (! typeJson.test(req.get('Content-Type'))) {
+        return res.status(415).send({'error':'Unsupported Media Type'});
+    }
+
+    var prop = req.body;
+    if (! config.LIBRARY.hasOwnProperty(req.params.key)) {
+        return res.status(400).send({'error':'Bad Format', 'message':'Invalid Property', 'property':req.params.key});
+    }
+    if (! (prop instanceof Array)) {
+        return res.status(400).send({'error':'Bad Format', 'message':'Invalid Type', 'property':req.params.key});
+    }
+
+    config.LIBRARY[req.params.key] = prop
+    config.save();
+    res.send(config.LIBRARY[req.params.key]);
+}
+
+/**
+ * patch /library/:key
+ *
+ * Append to the key
+ */
+exports.patch = function(req, res) {
+
+    if (! typeJson.test(req.get('Content-Type'))) {
+        return res.status(415).send({'error':'Unsupported Media Type'});
+    }
+
+    var prop = req.body;
+    if (! config.LIBRARY.hasOwnProperty(req.params.key)) {
+        return res.status(400).send({'error':'Bad Format', 'message':'Invalid Property', 'property':req.params.key});
+    }
+    if (! (prop instanceof Array)) {
+        return res.status(400).send({'error':'Bad Format', 'message':'Invalid Type', 'property':req.params.key});
+    }
+
+    config.LIBRARY[req.params.key].push.apply(config.LIBRARY[req.params.key], prop);
+    config.save();
+    res.send(config.LIBRARY[req.params.key]);
+}
+
+/**
+ * delete /library/:key
+ *
+ */
+exports.destroy = function(req, res) {
+
+    if (! config.LIBRARY.hasOwnProperty(req.params.key)) {
+        return res.status(404).send({'error':'Not Found'});
+    }
+
+    config.LIBRARY[req.params.key] = [];
+    config.save();
+    res.status(204).send();
+}

--- a/routes/music.js
+++ b/routes/music.js
@@ -1,21 +1,23 @@
 /**
  * @fileoverview Music music endpoint
  *
+ * @TODO: Use JSON for post, put and patch requests
  * @author ojourmel
  */
 
-var music = require('../dao/music');
+var music = require('../dao/music'),
+    url = require('url');
 
 /**
  * get /music
  *
  */
-exports.findAll = function(req, res) {
-    music.find().lean().exec(function(err, musics) {
+exports.index = function(req, res) {
+    music.find().lean().exec(function(err, m) {
         if (err) {
             res.status(404).send({'error':'Not Found'});
         } else {
-            res.send(musics);
+            res.send(m);
         }
     });
 }
@@ -24,7 +26,7 @@ exports.findAll = function(req, res) {
  * get /music/:id
  *
  */
-exports.findById = function(req, res) {
+exports.show = function(req, res) {
     music.findOne({_id: req.params.id}).lean().exec(function(err, m) {
         if (err || !m) {
             res.status(404).send({'error':'Not Found'});
@@ -38,7 +40,7 @@ exports.findById = function(req, res) {
  * post /music
  *
  */
-exports.addMusic = function(req, res) {
+exports.create = function(req, res) {
 
     var m = new music({ name: req.body.name,
                         year: req.body.year,
@@ -54,7 +56,15 @@ exports.addMusic = function(req, res) {
                 res.status(500).send({'error':'Internal Server Error'},
                                      {'error':err});
             }
-            res.send(m.toObject());
+            var loc = url.format(
+                        {
+                            protocol: req.protocol,
+                            host: req.get('host'),
+                            pathname: req.originalUrl
+                        });
+            loc += (loc.charAt(loc.length-1) == '/') ? m._id : '/' + m._id;
+            res.location(loc);
+            res.status(201).send(m.toObject());
         });
     } else {
         res.status(400).send({'error':'Bad Format'});
@@ -65,7 +75,7 @@ exports.addMusic = function(req, res) {
  * put /music/:id
  *
  */
-exports.updateMusic = function(req, res) {
+exports.update = function(req, res) {
     music.findOne({_id: req.params.id},function(err, m) {
         if (err || !m) {
             res.status(404).send({'error':'Not Found'});
@@ -95,10 +105,43 @@ exports.updateMusic = function(req, res) {
 }
 
 /**
+ * patch /music/:id
+ *
+ */
+exports.patch = function(req, res) {
+    music.findOne({_id: req.params.id},function(err, m) {
+        if (err || !m) {
+            res.status(404).send({'error':'Not Found'});
+        } else {
+            m.name = req.body.name || m.name;
+            m.year = req.body.year || m.year;
+            m.artist = req.body.artist || m.artist;
+            m.album = req.body.album || m.album;
+            m.label = req.body.label || m.label;
+            m.format = req.body.format || m.format;
+            m.path = req.body.path || m.path;
+
+            if (m.name && m.path && m.format) {
+                m.save(function(err){
+                    if (err) {
+                        res.status(500).send({'error':'Internal Server Error'},
+                                             {'error':err});
+                    } else {
+                        res.send(m.toObject());
+                    }
+                });
+            } else {
+                res.status(400).send({'error':'Bad Format'});
+            }
+        }
+    });
+}
+
+/**
  * delete /music/:id
  *
  */
-exports.deleteMusic = function(req, res) {
+exports.destroy = function(req, res) {
     music.findOne({_id: req.params.id},function(err, m) {
         if (err || !m) {
             res.status(404).send({'error':'Not Found'});

--- a/routes/stream.js
+++ b/routes/stream.js
@@ -1,11 +1,14 @@
 /**
  * @fileoverview Generic file serving endpoint
  *
+ * Assume paths are relative to the *LIBRARY_ROOT*. This may present some issues
+ * when using multiple folders for each MUSIC, MOVIE, etc library
+ *
  * @author ojourmel
  */
 
-var LIBRARYROOT = process.env.LIBRARY_ROOT;
 var file = require('../dao/file'),
+    config = require('../config'),
     fs = require('fs'),
     path = require('path');
 
@@ -14,12 +17,12 @@ var file = require('../dao/file'),
  * get /serve/:id
  *
  */
-exports.serve = function(req, res) {
+exports.show = function(req, res) {
     file.findOne({_id: req.params.id}).lean().exec(function(err, f) {
         if (err || !f) {
             res.status(404).send({'error':'Not Found'});
         } else {
-            var filepath = path.join(LIBRARYROOT, f.path);
+            var filepath = path.join(config.LIBRARY_ROOT, f.path);
             var readStream = fs.createReadStream(filepath);
 
             readStream.on('open', function () {

--- a/server.js
+++ b/server.js
@@ -12,19 +12,21 @@ var express = require('express'),
     bodyParser = require('body-parser'),
     multer = require('multer'),
     mongoose = require('mongoose'),
+    config = require('./config'),
     music = require('./routes/music'),
-    stream = require('./routes/stream');
+    stream = require('./routes/stream'),
+    library = require('./routes/library');
+
+config.load();
 
 var app = express();
 
-var env = process.env.NODE_ENV || 'development';
-if ('development' == env) {
+if ('development' == config.NODE_ENV) {
     app.use(logger('dev'));
 }
 
-
 // Start a mongoose connection
-mongoose.connect('omp-mongo');
+mongoose.connect(config.MONGO_HOST);
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -32,13 +34,36 @@ app.use(bodyParser.urlencoded({ extended: true }));
 // app.use(multer({dest:'./uploads/'}).single('photo'));
 
 // Serve endpoint code
-app.get('/music', music.findAll);
-app.get('/music/:id', music.findById);
-app.post('/music', music.addMusic);
-app.put('/music/:id', music.updateMusic);
-app.delete('/music/:id', music.deleteMusic);
 
-app.get('/stream/:id', stream.serve);
+/*
+ * @TODO: Merge /music/ and /library/ endpoints so that
+ *        /library/music/:id get calls music.show
+ *        This might require some fancy mongoose modeling
+ *        Note that library.show would be overridded with music.index
+ *        or some more general file.index
+ *
+ *        There would have to be some non-generic code when assigning
+ *        the various 'extra' file tags for music, movies, etc
+ *
+ *        Otherwise, the only difference between music.index and tv.index
+ *        is the model that is used in MODEL.find().lean).exec(...);
+ *
+ */
+app.get('/music', music.index);
+app.get('/music/:id', music.show);
+app.post('/music', music.create);
+app.put('/music/:id', music.update);
+app.patch('/music/:id', music.patch);
+app.delete('/music/:id', music.destroy);
 
-app.listen(8001);
-console.log('Listening on port 8001...');
+app.get('/stream/:id', stream.show);
+
+app.get('/library/', library.index);
+app.get('/library/:key', library.show);
+app.post('/library', library.create);
+app.put('/library/:key', library.update);
+app.patch('/library/:key', library.patch);
+app.delete('/library/:key', library.destroy);
+
+app.listen(config.API_PORT);
+console.log('Listening on port ' + config.API_PORT);

--- a/test/jsonArray.js
+++ b/test/jsonArray.js
@@ -1,0 +1,37 @@
+/**
+*
+* jsonArray.equal is used to avoid bad mocha checks of returning JSON
+*
+* Use the following code structure:
+*
+*    .expect(function(res) {
+*         var r = jsonArray.equal(res.body.p1 , object.p1) ||
+*                 jsonArray.equal(res.body.p2 , object.p2) ||
+*                 jsonArray.equal(res.body.p3 , object.p3);
+*
+*         if (r) {
+*             throw new Error(r);
+*         }
+*    })
+*
+* @author ojourmel
+*/
+
+exports.equal = function (j1, j2)
+{
+
+    if ((j1 instanceof Array) && (j2 instanceof Array)) {
+        if (j1.length === j2.length) {
+            var l = j1.length;
+            for(var i=0;i<l;i++){
+                if (j1.indexOf(j2[i]) < 0) {
+                        return "Error: " + j1 + " != " + j2 + " As " + j1[i] + " != " + j2[i];
+                }
+            }
+        } else {
+            return "Error: " + j1 + ", " + j2 + " are not the same length, " + j1.length + ", " + j2.length;
+        }
+    } else {
+        return "Error: " + j1 + ", " + j2 + " are not both arrays";
+    }
+}

--- a/test/library.js
+++ b/test/library.js
@@ -1,0 +1,262 @@
+/**
+* Testing for library api
+*
+* @see jsonArray to avoid bad mocha checks of returning JSON
+*
+* @author ojourmel
+*/
+
+var request = require('supertest'),
+    jsonArray = require('./jsonArray');
+
+request = request("http://localhost:8001");
+
+// populate the database with a few items:
+var lib = {
+    MUSIC: ['m1','m2'],
+    PHOTOS: ['p1','p2'],
+    TV: ['t1','t2'],
+    MOVIES: ['mo1','mo'],
+    OTHER: ['o1','o2']
+}
+
+describe('library api', function () {
+
+    it('should respond to an empty /library get', function (done) {
+        request
+            .get('/library')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(function(res) {
+                var r = jsonArray.equal(res.body.MUSIC , []) ||
+                       jsonArray.equal(res.body.PHOTOS , []) ||
+                       jsonArray.equal(res.body.TV , []) ||
+                       jsonArray.equal(res.body.MOVIES , []) ||
+                       jsonArray.equal(res.body.OTHER , []);
+
+                if (r) {
+                    throw new Error(r);
+                }
+            })
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
+    it('should respond to /library post', function (done) {
+        request
+            .post('/library')
+            .set('Content-Type', 'application/json')
+            .send(lib)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(function(res) {
+                var r = jsonArray.equal(res.body.MUSIC , lib.MUSIC) ||
+                       jsonArray.equal(res.body.PHOTOS , lib.PHOTOS) ||
+                       jsonArray.equal(res.body.TV , lib.TV) ||
+                       jsonArray.equal(res.body.MOVIES , lib.MOVIES) ||
+                       jsonArray.equal(res.body.OTHER , lib.OTHER);
+
+                if (r) {
+                    throw new Error(r);
+                }
+            })
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
+    it('should reject non json /library post', function (done) {
+        request
+            .post('/library')
+            .expect(415, done);
+    });
+
+    it('should reject non standard keys in /library post', function (done) {
+        lib.extra = ['qwer','zxcv'];
+        request
+            .post('/library')
+            .set('Content-Type', 'application/json')
+            .send(lib)
+            .expect(400, done);
+
+        delete lib.extra;
+    });
+
+    it('should reject non array keys in /library post', function (done) {
+        lib.TV = {'key':'value'};
+        request
+            .post('/library')
+            .set('Content-Type', 'application/json')
+            .send(lib)
+            .expect(400, done);
+        lib.TV = ['t1','t2'];
+    });
+
+    it('should reject non json /library/:key put', function (done) {
+        request
+            .put('/library/MUSIC')
+            .expect(415, done);
+    });
+
+    it('should reject non standard keys in /library/:key put', function (done) {
+        request
+            .put('/library/BADKEY')
+            .set('Content-Type', 'application/json')
+            .expect(400, done);
+    });
+
+    it('should reject non array keys in /library/:key put', function (done) {
+        request
+            .put('/library/MUSIC')
+            .set('Content-Type', 'application/json')
+            .send({'key':'value'})
+            .expect(400, done);
+    });
+
+    it('should respond to valid /library/:key put', function (done) {
+        lib.MUSIC = ['tm1','tm2'];
+        request
+            .put('/library/MUSIC')
+            .set('Content-Type', 'application/json')
+            .send(lib.MUSIC)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(function(res) {
+                var r = jsonArray.equal(res.body , lib.MUSIC);
+                if (r) {
+                    throw new Error(r);
+                }
+            })
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
+    it('should reject non json /library/:key patch', function (done) {
+        request
+            .patch('/library/MUSIC')
+            .expect(415, done);
+    });
+
+    it('should reject non standard keys in /library/:key patch', function (done) {
+        request
+            .patch('/library/BADKEY')
+            .set('Content-Type', 'application/json')
+            .expect(400, done);
+    });
+
+    it('should reject non array keys in /library/:key patch', function (done) {
+        request
+            .patch('/library/MUSIC')
+            .set('Content-Type', 'application/json')
+            .send({'key':'value'})
+            .expect(400, done);
+    });
+
+    it('should respond to valid /library/:key patch', function (done) {
+        var extra = ['e1','e2'];
+        var combined = lib.MUSIC.concat(extra);
+        request
+            .patch('/library/MUSIC')
+            .set('Content-Type', 'application/json')
+            .send(extra)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(function(res) {
+                var r = jsonArray.equal(res.body , combined);
+                if (r) {
+                    throw new Error(r);
+                }
+            })
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
+    it('should respond to /library/:key delete ', function (done) {
+        request
+            .delete('/library/MUSIC')
+            .expect(204, done);
+    });
+
+    it('should 404 bad key to /library/:key delete ', function (done) {
+        request
+            .delete('/library/BADKEY')
+            .expect(404, done);
+    });
+
+    it('should respect delete from /library get', function (done) {
+        lib.MUSIC = [];
+        request
+            .get('/library')
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(function(res) {
+                var r = jsonArray.equal(res.body.MUSIC , lib.MUSIC) ||
+                       jsonArray.equal(res.body.PHOTOS , lib.PHOTOS) ||
+                       jsonArray.equal(res.body.TV , lib.TV) ||
+                       jsonArray.equal(res.body.MOVIES , lib.MOVIES) ||
+                       jsonArray.equal(res.body.OTHER , lib.OTHER);
+
+                if (r) {
+                    throw new Error(r);
+                }
+            })
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+
+    it('should finish with an empty /library post', function (done) {
+        lib.MUSIC = [];
+        lib.PHOTOS = [];
+        lib.TV = [];
+        lib.MOVIES = [];
+        lib.OTHER = [];
+        request
+            .post('/library')
+            .set('Content-Type', 'application/json')
+            .send(lib)
+            .expect(200)
+            .expect('Content-Type', /json/)
+            .expect(function(res) {
+                var r = jsonArray.equal(res.body.MUSIC , lib.MUSIC) ||
+                       jsonArray.equal(res.body.PHOTOS , lib.PHOTOS) ||
+                       jsonArray.equal(res.body.TV , lib.TV) ||
+                       jsonArray.equal(res.body.MOVIES , lib.MOVIES) ||
+                       jsonArray.equal(res.body.OTHER , lib.OTHER);
+
+                if (r) {
+                    throw new Error(r);
+                }
+            })
+            .end(function (err, res) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+    });
+});

--- a/test/stream.js
+++ b/test/stream.js
@@ -8,8 +8,6 @@
 var request = require('supertest'),
     jsonProperty = require('./jsonProperty');
 
-// Connect to an alread running instance of the app
-// This includes are running docker-compose instance
 request = request("http://localhost:8001");
 
 // Use the README.md file for testing purposes
@@ -43,8 +41,8 @@ describe('stream api', function () {
                 // here is the actual test
                 request
                     .get('/stream/' + file._id)
-                    .expect('Content-Type', new RegExp('^' + file.format + '.*'))
                     .expect(200)
+                    .expect('Content-Type', new RegExp('^' + file.format + '.*'))
                     .end(function (err, res) {
 
                         // Clean up test data, again, dependent on /music/


### PR DESCRIPTION
- Use `omp-config.yml` as the storage for configs.
  This uses the `js-yaml` npm package, and is
  interfaced by `config.js`.
- Implement full REST `/library/` endpoint.
  Uses `JSON` request body for `POST`/`PUT`/`PATCH`.
  Changes to the `LIBRARY` configuration should trigger reboots
  of the docker-compose containers, as new volumes will
  need to be mounted. Additionally, the master `OpenMediaPortal`
  configure script will need to read `omp-config.yml` to determine
  these volumes. `omp-config.yml` will be located in the `OpenMediaPortal`
  repo, and will be mounted into the `BACKEND` root directory.
- Update naming scheme for other endpoints, and adds location
  header to `/music/` post.
- Implements unit tests for `/library/` and tweaks the order of
  tests for `/music/` and `/stream/` to check for status codes
  before anything else.
