### PR TITLE
File group sort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:slim
 
 RUN mkdir -p /omp
 WORKDIR /omp

--- a/dao/file.js
+++ b/dao/file.js
@@ -15,6 +15,7 @@ var fileSchema = new Schema({
     name: {type: String },
     mimetype: {type: String },
     path: {type: String },
+    title: {type: String },
     year: {type: String },
     artist: {type: String },
     album: {type: String },
@@ -37,6 +38,7 @@ fileSchema.statics.parseJSON = function(libkey, body, f) {
 
             if (lm == 'audio') {
 
+                f.title = body.title;
                 f.artist = body.artist;
                 f.album = body.album;
                 f.year = body.year;
@@ -57,7 +59,7 @@ fileSchema.statics.parseJSON = function(libkey, body, f) {
     return f;
 }
 
-fileSchema.statics.parsePath = function(libkey, n, p, t, f) {
+fileSchema.statics.parsePath = function(libkey, n, p, m, f) {
 
     if (config.library.hasOwnProperty(libkey)) {
 
@@ -68,12 +70,22 @@ fileSchema.statics.parsePath = function(libkey, n, p, t, f) {
         f.library = libkey;
         f.name = n;
         f.path = p;
-        f.mimetype = t;
+        f.mimetype = m;
 
         var lm = config.library[libkey].libmime;
 
         if (lm == 'audio') {
             // parse mp3 tags, or pull from path
+
+            // Assume /artist/alubm/song.ext format
+            // Replace with libtag once V8 issues are resolved
+            // https://github.com/nikhilm/node-taglib/pull/63
+            var info = p.split(path.sep);
+
+            f.title = path.basename(p, path.extname(p));
+            f.album = info[info.length - 2];
+            f.artist = info[info.length - 3];
+
         } else if (lm == 'image') {
             // parse image tags, or pull from path
         } else if (lm == 'video') {

--- a/routes/file.js
+++ b/routes/file.js
@@ -42,12 +42,15 @@ exports.index = function(req, res) {
      *              "21 Guns" : [[0,0]]
      *          }
      *      },
+     *      lookup: {
+     *          "1234": 0
+     *      }
      *      files: [
      *          {
-     *          id: "1234",
-     *          title: "21 Guns",
-     *          artist : "Green Day",
-     *          album : "21st Century",
+     *              id: "1234",
+     *              title: "21 Guns",
+     *              artist : "Green Day",
+     *              album : "21st Century",
      *          }
      *      ]
      *  }
@@ -56,6 +59,7 @@ exports.index = function(req, res) {
     var f = {
         group: [],
         index: {},
+        lookup: {},
         files: []
     };
     var group = req.query.group;
@@ -127,8 +131,8 @@ exports.index = function(req, res) {
                         }
                     }
                 }
+                f.lookup[f.files[i]._id] = i;
             }
-
             res.send(f);
         }
     });

--- a/routes/file.js
+++ b/routes/file.js
@@ -13,7 +13,7 @@ var typeJson = new RegExp('^application/json');
 
 
 /**
- * get /library/:libkey
+ * get /library/:libkey?group=:group&sort=:sort
  *
  */
 exports.index = function(req, res) {
@@ -22,11 +22,113 @@ exports.index = function(req, res) {
         return res.status(404).send({'error':'Not Found'});
     }
 
-    file.find({library: libkey}).lean().exec(function(err, f) {
+    /*
+     * Response object from /library/music/?group=artist,album,title
+     *
+     *  f: {
+     *      group: [
+     *          "artist",
+     *          "album",
+     *          "title"
+     *      ],
+     *      index: {
+     *          artist: {
+     *              "Green Day" : [[0,0]]
+     *          },
+     *          album: {
+     *              "21st Century" : [[0,0]]
+     *          },
+     *          title: {
+     *              "21 Guns" : [[0,0]]
+     *          }
+     *      },
+     *      files: [
+     *          {
+     *          id: "1234",
+     *          title: "21 Guns",
+     *          artist : "Green Day",
+     *          album : "21st Century",
+     *          }
+     *      ]
+     *  }
+     *
+     */
+    var f = {
+        group: [],
+        index: {},
+        files: []
+    };
+    var group = req.query.group;
+    var sort = req.query.sort;
+
+    // Sort object passed to Mongo (GroupSort)
+    var gs = {};
+
+    // Sort flat results by group first
+    // use 'truthy' check for group and sort
+    if ( group ) {
+        group = group.split(",");
+
+        for (var i=0; i<group.length; i++) {
+            gs[group[i]] = 1;
+            f.index[group[i]] = {};
+        }
+    } else {
+        group = ["name"];
+        f.index[group[0]] = {};
+    }
+
+    // add sorting (alphabetical, etc) after
+    // applied within each subgroup of the grouping
+    if ( sort ) {
+        sort = sort.split(",");
+        for (var i=0; i<sort.length; i++) {
+            // Support only alphabetical A-Z for now
+            // Use -1 for Z-A
+            gs[sort[i]] = 1;
+        }
+    } else {
+        sort = ["name"];
+    }
+
+    // execute query
+    file.find({library: libkey}, {library: 0, path: 0, __v:0}).sort(gs).exec(function(err, results) {
         if (err) {
             res.status(500).send([{'error':'Internal Server Error'},
                                  {'error':err}]);
         } else {
+            f.group = group;
+            f.files = results;
+
+            // Build the index. Brute force update each group
+            // info for each file
+            for (var i=0; i<f.files.length; i++) {
+                for (var j=0; j<group.length; j++) {
+                    var key = f.files[i][group[j]];
+
+                    if ( key ) {
+                        // Group does not exist in index.
+                        // Add the basic [[i,i]] entry
+                        if (f.index[group[j]][key] == null) {
+                            f.index[group[j]][key] = [[i,i]];
+                        } else {
+                            var last = f.index[group[j]][key].pop();
+                            // This file is adjacent to the current group entry
+                            // Modify it from [[x,y], [x,i]]
+                            if ((last[1]+1) == i) {
+                                last[1]++;
+                                f.index[group[j]][key].push(last);
+                            // This file is *not* adjacent. Add a new
+                            // [i,i] entry giving: [[a,a], [b,b], ... ,[i,i]]
+                            } else {
+                                f.index[group[j]][key].push(last);
+                                f.index[group[j]][key].push([i,i]);
+                            }
+                        }
+                    }
+                }
+            }
+
             res.send(f);
         }
     });
@@ -42,7 +144,7 @@ exports.show = function(req, res) {
         return res.status(404).send({'error':'Not Found'});
     }
 
-    file.findOne({library: libkey, _id: req.params.id}).lean().exec(function(err, f) {
+    file.findOne({library: libkey, _id: req.params.id}, {__v:0}).lean().exec(function(err, f) {
         if (err || !f) {
             res.status(404).send({'error':'Not Found'});
         } else {

--- a/routes/stream.js
+++ b/routes/stream.js
@@ -14,7 +14,7 @@ var file = require('../dao/file'),
 
 
 /**
- * get /serve/:id
+ * get /stream/:id
  *
  */
 exports.show = function(req, res) {

--- a/routes/sync.js
+++ b/routes/sync.js
@@ -127,11 +127,11 @@ exports.update = function(req, res) {
                         walker.on("file", function (root, stats, next) {
 
                             var n = stats.name;
-                            var t = mime.lookup(n).toString();
-                            var p = "/" + path.join(root, n).toString().substr(config.LIBRARY_ROOT.length);
+                            var m = mime.lookup(stats.name).toString();
+                            var p = "/" + path.join(root, stats.name).toString().substr(config.LIBRARY_ROOT.length);
 
-                            if (t.match(config.library[libkey].libmime)) {
-                                var f = file.parsePath(libkey, n, p, t );
+                            if (m.match(config.library[libkey].libmime)) {
+                                var f = file.parsePath(libkey, n, p, m );
                                 f.save(function () {
                                     s.status.totalFiles++;
                                     s.status.syncTime = Date.now() - s.lastSynced;

--- a/test/daofile.js
+++ b/test/daofile.js
@@ -213,11 +213,11 @@ describe('file parsePath', function () {
         config.library.testlibkey = {libmime: 'text', libpath: []};
 
 
-        var p = '/test/path.txt';
-        var n = 'path.txt';
-        var t = 'text/plain';
+        var path = '/test/path.txt';
+        var name = 'path.txt';
+        var mime = 'text/plain';
 
-        var f = file.parsePath('testlibkey', n, p, t, null);
+        var f = file.parsePath('testlibkey', name, path, mime, null);
 
         if (!f) {
             throw new Error('Error: null file');
@@ -226,9 +226,9 @@ describe('file parsePath', function () {
         f = f.toObject();
 
         var r = jsonCompare.property(f.library ,'testlibkey' ) ||
-                jsonCompare.property(f.name, n) ||
-                jsonCompare.property(f.path, p) ||
-                jsonCompare.property(f.mimetype, t);
+                jsonCompare.property(f.name, name) ||
+                jsonCompare.property(f.path, path) ||
+                jsonCompare.property(f.mimetype, mime);
 
         if (r) {
             throw new Error(r);

--- a/test/file.js
+++ b/test/file.js
@@ -26,6 +26,7 @@ if ('coverage' == process.env.NODE_ENV) {
 // populate the database with a few items:
 var music = {
     name: "TestName",
+    title: "TestTitle",
     year: "0000",
     artist: "TestArtist",
     album: "TestAlbum",
@@ -36,6 +37,7 @@ var music = {
 
 var extra = {
     name: "ExtraName",
+    title: "ExtraTitle",
     year: "9999",
     artist: "ExtraArtist",
     album: "ExtraAlbum",
@@ -46,6 +48,12 @@ var extra = {
 
 };
 
+var emptyResp = {
+    group: ["name"],
+    index: { "name": [] },
+    files: []
+}
+
 describe('file (/library/:libkey) api', function () {
 
     it('should respond to an empty /library/music get', function (done) {
@@ -53,7 +61,7 @@ describe('file (/library/:libkey) api', function () {
             .get('/library/music')
             .expect(200)
             .expect('Content-Type', /json/)
-            .expect([], done);
+            .expect(emptyResp, done);
     });
 
     it('should 404 a bad libkey to /library/:libkey post', function (done) {
@@ -79,6 +87,7 @@ describe('file (/library/:libkey) api', function () {
             .expect('Content-Type', /json/)
             .expect(function(res) {
                 var r = jsonCompare.property(res.body.name , music.name) ||
+                       jsonCompare.property(res.body.title , music.title) ||
                        jsonCompare.property(res.body.year , music.year) ||
                        jsonCompare.property(res.body.artist , music.artist) ||
                        jsonCompare.property(res.body.album , music.album) ||
@@ -110,6 +119,7 @@ describe('file (/library/:libkey) api', function () {
             .expect(function(res) {
 
                 var r = jsonCompare.property(res.body.name , extra.name) ||
+                       jsonCompare.property(res.body.title , extra.title) ||
                        jsonCompare.property(res.body.year , extra.year) ||
                        jsonCompare.property(res.body.artist , extra.artist) ||
                        jsonCompare.property(res.body.album , extra.album) ||
@@ -135,9 +145,8 @@ describe('file (/library/:libkey) api', function () {
 
     it('should 400 empty path /library/music post', function (done) {
         var tmp = {
-            name: 'empty',
-            mimetype: 'exe',
-            year: 'thing'
+            name: 'empty.exe',
+            mimetype: 'exe'
         }
 
         request
@@ -149,7 +158,6 @@ describe('file (/library/:libkey) api', function () {
 
     it('should 400 empty name /library/music post', function (done) {
         var tmp = {
-            year: 'thing',
             mimetype: 'exe',
             path: '/path/'
         }
@@ -163,7 +171,6 @@ describe('file (/library/:libkey) api', function () {
     it('should 400 empty mimetype /library/music post', function (done) {
         var tmp = {
             name: 'name',
-            year: 'thing',
             path: '/path/'
         }
         request
@@ -176,8 +183,7 @@ describe('file (/library/:libkey) api', function () {
     it('should 400 empty path /library/music put', function (done) {
         var tmp = {
             name: 'empty',
-            mimetype: 'exe',
-            year: 'thing'
+            mimetype: 'exe'
         }
 
         request
@@ -189,7 +195,6 @@ describe('file (/library/:libkey) api', function () {
 
     it('should 400 empty name /library/music put', function (done) {
         var tmp = {
-            year: 'thing',
             mimetype: 'exe',
             path: '/path/'
         }
@@ -203,7 +208,6 @@ describe('file (/library/:libkey) api', function () {
     it('should 400 empty mimetype /library/music put', function (done) {
         var tmp = {
             name: 'name',
-            year: 'thing',
             path: '/path/'
         }
         request
@@ -239,6 +243,7 @@ describe('file (/library/:libkey) api', function () {
             .expect(function(res) {
 
                 var r = jsonCompare.property(res.body.name , music.name) ||
+                       jsonCompare.property(res.body.title , music.title) ||
                        jsonCompare.property(res.body.year , music.year) ||
                        jsonCompare.property(res.body.artist , music.artist) ||
                        jsonCompare.property(res.body.album , music.album) ||
@@ -294,6 +299,7 @@ describe('file (/library/:libkey) api', function () {
             .expect('Content-Type', /json/)
             .expect(function(res) {
                 var r = jsonCompare.property(res.body.name , music.name) ||
+                       jsonCompare.property(res.body.title , music.title) ||
                        jsonCompare.property(res.body.year , music.year) ||
                        jsonCompare.property(res.body.artist , music.artist) ||
                        jsonCompare.property(res.body.album , music.album) ||
@@ -321,6 +327,7 @@ describe('file (/library/:libkey) api', function () {
             .expect('Content-Type', /json/)
             .expect(function(res) {
                 var r = jsonCompare.property(res.body.name , music.name) ||
+                       jsonCompare.property(res.body.title , music.title) ||
                        jsonCompare.property(res.body.year , music.year) ||
                        jsonCompare.property(res.body.artist , music.artist) ||
                        jsonCompare.property(res.body.album , music.album) ||
@@ -370,7 +377,7 @@ describe('file (/library/:libkey) api', function () {
             .get('/library/music')
             .expect(200)
             .expect('Content-Type', /json/)
-            .expect([], done);
+            .expect(emptyResp, done);
     });
 
 });

--- a/test/file.js
+++ b/test/file.js
@@ -50,7 +50,8 @@ var extra = {
 
 var emptyResp = {
     group: ["name"],
-    index: { "name": [] },
+    index: { "name": {} },
+    lookup: {},
     files: []
 }
 

--- a/test/jsonCompare.js
+++ b/test/jsonCompare.js
@@ -26,14 +26,14 @@ exports.array = function (j1, j2)
             var l = j1.length;
             for(var i=0;i<l;i++){
                 if (j1.indexOf(j2[i]) < 0) {
-                        return "Error: " + j1 + " != " + j2 + " As " + j1[i] + " != " + j2[i];
+                        return j1 + " != " + j2 + " As " + j1[i] + " != " + j2[i];
                 }
             }
         } else {
-            return "Error: " + j1 + ", " + j2 + " are not the same length, " + j1.length + ", " + j2.length;
+            return j1 + ", " + j2 + " are not the same length, " + j1.length + ", " + j2.length;
         }
     } else {
-        return "Error: " + j1 + ", " + j2 + " are not both arrays";
+        return j1 + ", " + j2 + " are not both arrays";
     }
 }
 
@@ -59,7 +59,7 @@ exports.array = function (j1, j2)
 exports.property = function (j1, j2)
 {
     if (j1 != j2) {
-        return "Error: " + j1 + " != " + j2;
+        return j1 + " != " + j2;
     } else {
         return null;
     }

--- a/test/stream.js
+++ b/test/stream.js
@@ -16,7 +16,7 @@ if ('coverage' == process.env.NODE_ENV) {
 // Use the README.md file for testing purposes
 // This file is mounted in .travis-docker-compose.yml
 var file = {
-    name: "readme",
+    name: "README.md",
     mimetype: "text/plain"
 };
 


### PR DESCRIPTION
Update the `GET` `/library/:libkey` api endpoint to serve a better structured JSON.

Include a `group` and `sort` URL parameters that are used to embed hierarchical data in the flat file listing.
